### PR TITLE
Create symlinks in /usr/bin instead of /usr/sbin.

### DIFF
--- a/recipes/rubygems-install.rb
+++ b/recipes/rubygems-install.rb
@@ -213,7 +213,7 @@ when "init"
       mode 0644
     end
 
-    link "/usr/sbin/#{svc}" do
+    link "/usr/bin/#{svc}" do
       to "#{node['languages']['ruby']['bin_dir']}/#{svc}"
     end
 


### PR DESCRIPTION
When using init instead of runit, the rubygems-install recipe
creates symlinks in /usr/sbin, but all of the /etc/init.d/ scripts
in the gem are hardcoded to look in /usr/bin instead.
