### PR TITLE
Update the way rabbit is installed and configured for chef server

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The chef-server cookbook requires the following cookbooks from Opscode. Some are
 * daemontools
 * ucspi-tcp
 * build-essential
+* rabbitmq 
 
 ATTRIBUTES
 ==========

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,16 +3,17 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures Chef Server"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.99.12"
+version           "0.99.13"
 recipe            "chef-server", "Compacts the Chef Server CouchDB."
 recipe            "chef-server::rubygems-install", "Set up rubygem installed chef server."
 recipe            "chef-server::apache-proxy", "Configures Apache2 proxy for API and WebUI"
 recipe            "chef-server::nginx-proxy", "Configures NGINX proxy for API and WebUI"
+recipe            "chef-server::rabbitmq", "Installs and configures rabbitmq to support chef server."
 
 %w{ ubuntu debian redhat centos fedora freebsd openbsd }.each do |os|
   supports os
 end
 
-%w{ runit bluepill daemontools couchdb apache2 nginx openssl zlib xml java gecode }.each do |cb|
+%w{ rabbitmq runit bluepill daemontools couchdb apache2 nginx openssl zlib xml java gecode }.each do |cb|
   depends cb
 end

--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Daniel DeLeo <dan@kallistec.com>
 # Author:: Joshua Timberman <joshua@opscode.com>
+# Author:: Subhobroto Sinha <subhobroto@gmail.com>
 #
 # Cookbook Name:: rabbitmq
 # Recipe:: chef
@@ -20,28 +21,7 @@
 # limitations under the License.
 #
 
-def debian_before_squeeze?
-  platform?("debian") && (node.platform_version.to_f < 5.0 || (node.platform_version.to_f == 5.0 && node.platform_version !~ /.*sid/ ))
-end
-
-if (platform?("ubuntu") && node.platform_version.to_f <= 9.10) || debian_before_squeeze?
-  include_recipe("erlang")
-
-  rabbitmq_dpkg_path = ::File.join(Chef::Config[:file_cache_path], "/", "rabbitmq-server_1.7.2-1_all.deb")
-
-  remote_file(rabbitmq_dpkg_path) do
-    checksum "ea2bbbb41f6d539884498bbdb5c7d3984643127dbdad5e9f7c28ec9df76b1355"
-    source "http://mirror.rabbitmq.com/releases/rabbitmq-server/v1.7.2/rabbitmq-server_1.7.2-1_all.deb"
-  end
-
-  dpkg_package(rabbitmq_dpkg_path) do
-    source rabbitmq_dpkg_path
-    version '1.7.2-1'
-    action :install
-  end
-else
-  package "rabbitmq-server"
-end
+include_recipe "rabbitmq"
 
 service "rabbitmq-server" do
   if platform?("centos","redhat","fedora")


### PR DESCRIPTION
Currently, the version of rabbit installed is the one included with the distro which is often quite old. We will probably get better results directly installing from their repository.

This patch makes that happen by leveraging the rabbitmq cookbook.

This is under the CLA referenced by Transaction ID: MBHASA2TX6XD54
