### PR TITLE
[COOK-886] cookbook links binaries to /usr/sbin but the init files point to /usr/bin

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,6 +44,7 @@ else
   default["chef_server"]["backup_path"] = "/var/chef/backup"
 end
 
+default['chef_server']['bin_path']        = "/usr/sbin"
 default['chef_server']['umask']           = "0022"
 default['chef_server']['url']             = "http://localhost:4000"
 default['chef_server']['log_dir']         = "/var/log/chef"

--- a/recipes/rubygems-install.rb
+++ b/recipes/rubygems-install.rb
@@ -200,11 +200,10 @@ when "init"
   gems_dir = node['languages']['ruby']['gems_dir']
 
   server_services.each do |svc|
-    init_content = IO.read("#{gems_dir}/gems/chef-#{chef_version}/distro/#{dist_dir}/etc/init.d/#{svc}")
     conf_content = IO.read("#{gems_dir}/gems/chef-#{chef_version}/distro/#{dist_dir}/etc/#{conf_dir}/#{svc}")
 
-    file "/etc/init.d/#{svc}" do
-      content init_content
+    template "/etc/init.d/#{svc}" do
+      source "#{dist_dir}/init.d/#{svc}.erb"
       mode 0755
     end
 
@@ -213,7 +212,7 @@ when "init"
       mode 0644
     end
 
-    link "/usr/sbin/#{svc}" do
+    link "#{node['chef_server']['bin_path']}/#{svc}" do
       to "#{node['languages']['ruby']['bin_dir']}/#{svc}"
     end
 

--- a/templates/default/debian/init.d/chef-expander.erb
+++ b/templates/default/debian/init.d/chef-expander.erb
@@ -1,0 +1,176 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:           chef-expander
+# Required-Start:     $remote_fs $network rabbitmq-server chef-solr
+# Required-Stop:      $remote_fs $network rabbitmq-server chef-solr
+# Default-Start:      2 3 4 5
+# Default-Stop:       0 1 6
+# Short-Description:  Start a chef-expander.
+### END INIT INFO
+#
+# Copyright (c) 2009-2010 Opscode, Inc <legal@opscode.com>
+#
+# chef-expander         Startup script for chef-expander.
+# chkconfig: - 85 02
+# description: starts up chef-expander in daemon mode.
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=<%= node["chef_server"]["bin_path"] %>/chef-expander
+NAME=chef-expander
+DESC=chef-expander
+PIDFILE=<%= node["chef_server"]["run_path"] %>/expander.pid
+
+test -x $DAEMON || exit 0
+
+. /lib/lsb/init-functions
+
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+if [ ! -d <%= node["chef_server"]["run_path"] %> ]; then
+  mkdir <%= node["chef_server"]["run_path"] %>
+  chown $USER:$GROUP <%= node["chef_server"]["run_path"] %>
+fi
+
+DAEMON_OPTS="-d -c $CONFIG -P $PIDFILE -L $LOGFILE $CHEF_EXPANDER_ARGS"
+
+running_pid() {
+  pid=$1
+  name=$2
+  [ -z "$pid" ] && return 1
+  [ ! -d /proc/$pid ] &&  return 1
+  cmd=`cat /proc/$pid/cmdline | tr '\000' '\n' | awk 'NR==2'`
+  [ "$cmd" != "$name" ] &&  return 1
+  return 0
+}
+
+running() {
+  [ ! -f "$PIDFILE" ] && return 1
+  pid=`cat $PIDFILE`
+  running_pid $pid $DAEMON || return 1
+  return 0
+}
+
+start_server() {
+  if [ -z "$DAEMONUSER" ] ; then
+    start_daemon -p $PIDFILE $DAEMON $DAEMON_OPTS
+  errcode=$?
+  else
+    start-stop-daemon --start --quiet --pidfile $PIDFILE \
+      --chuid $DAEMONUSER \
+      --exec $DAEMON -- $DAEMON_OPTS
+    errcode=$?
+  fi
+  return $errcode
+}
+
+stop_server() {
+   if [ -z "$DAEMONUSER" ] ; then
+     killproc -p $PIDFILE $DAEMON
+     errcode=$?
+   else
+     start-stop-daemon --stop --quiet --pidfile $PIDFILE \
+       --user $DAEMONUSER \
+       --exec $DAEMON
+     errcode=$?
+   fi
+   return $errcode
+}
+
+reload_server() {
+  [ ! -f "$PIDFILE" ] && return 1
+  pid=pidofproc $PIDFILE # This is the daemon's pid
+  /bin/kill -1 $pid
+  return $?
+}
+
+force_stop() {
+  [ ! -e "$PIDFILE" ] && return
+  if running ; then
+    /bin/kill -15 $pid
+    sleep "$DIETIME"s
+    if running ; then
+      /bin/kill -9 $pid
+      sleep "$DIETIME"s
+      if running ; then
+        echo "Cannot kill $NAME (pid=$pid)!"
+        exit 1
+      fi
+    fi
+  fi
+  rm -f $PIDFILE
+}
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting $DESC " "$NAME"
+    if running ;  then
+        log_progress_msg "apparently already running"
+        log_end_msg 0
+        exit 3
+    fi
+    if start_server ; then
+        [ -n "$STARTTIME" ] && sleep $STARTTIME # Wait some time
+        if  running ;  then
+            log_end_msg 0
+        else
+            log_end_msg 1
+        fi
+    else
+        log_end_msg 1
+    fi
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC" "$NAME"
+    if running ; then
+      errcode=0
+      stop_server || errcode=$?
+      log_end_msg $errcode
+    else
+      log_progress_msg "apparently not running"
+      log_end_msg 0
+      exit 0
+    fi
+    ;;
+  force-stop)
+    $0 stop
+    if running; then
+      log_daemon_msg "Stopping (force) $DESC" "$NAME"
+      errcode=0
+      force_stop || errcode=$?
+      log_end_msg $errcode
+    fi
+    ;;
+  restart|force-reload)
+    log_daemon_msg "Restarting $DESC" "$NAME"
+    errcode=0
+    stop_server || errcode=$?
+    [ -n "$DIETIME" ] && sleep $DIETIME
+    start_server || errcode=$?
+    [ -n "$STARTTIME" ] && sleep $STARTTIME
+    running || errcode=$?
+    log_end_msg $errcode
+    ;;
+  status)
+    log_daemon_msg "Checking status of $DESC" "$NAME"
+    if running ;  then
+      log_progress_msg "running"
+      log_end_msg 0
+    else
+      log_progress_msg "apparently not running"
+      log_end_msg 1
+      exit 1
+    fi
+    ;;
+  reload)
+    log_warning_msg "Reloading $NAME daemon: not implemented, as the daemon"
+    log_warning_msg "cannot re-read the config file (use restart)."
+    ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N {start|stop|force-stop|restart|force-reload|status}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0
+

--- a/templates/default/debian/init.d/chef-server-webui.erb
+++ b/templates/default/debian/init.d/chef-server-webui.erb
@@ -1,0 +1,123 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:           chef-server-webui
+# Required-Start:     $remote_fs $network chef-server
+# Required-Stop:      $remote_fs $network chef-server
+# Default-Start:      2 3 4 5
+# Default-Stop:       0 1 6
+# Short-Description:  Start a chef-server-webui
+### END INIT INFO
+#
+# Copyright (c) 2009-2010 Opscode, Inc <legal@opscode.com>
+#
+# chef-server-webui   Startup script for chef-server-webui.
+# chkconfig: - 95 02
+# description: starts up chef-server webui.
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=<%= node["chef_server"]["bin_path"] %>/chef-server-webui
+PIDFILE=<%= node["chef_server"]["run_path"] %>/server-webui.%s.pid
+MAINPID=<%= node["chef_server"]["run_path"] %>/server-webui.main.pid
+NAME=chef-server-webui
+DESC=chef-server-webui
+
+test -x $DAEMON || exit 0
+
+. /lib/lsb/init-functions
+
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+if [ ! -d <%= node["chef_server"]["run_path"] %> ]; then
+  mkdir <%= node["chef_server"]["run_path"] %>
+  chown $USER:$GROUP <%= node["chef_server"]["run_path"] %>
+fi
+
+DAEMON_OPTS="-p $PORT -e production -d -a $ADAPTER -P $PIDFILE -L $LOGFILE -C $CONFIG -u $USER -G $GROUP"
+
+running() {
+  [ ! -f  "$MAINPID" ] &&  return 1
+  pid=`cat $MAINPID`
+  name=$WORKER
+  [ -z "$pid" ] && return 1
+  [ ! -d /proc/$pid ] && return 1
+  (ps -fp $pid | egrep -q "merb.*(merb : master|worker.*$PORT)") || return 1
+  return 0
+}
+
+start_server() {
+  $DAEMON $DAEMON_OPTS
+  errcode=$?
+  return $errcode
+}
+
+stop_server() {
+  $DAEMON -K all -P $PIDFILE
+  errcode=$?
+  return $errcode
+}
+
+reload_server() {
+  stop_server
+  [ -n "$DIETIME" ] && sleep $DIETIME
+  start_server
+  [ -n "$STARTTIME" ] && sleep $STARTTIME
+}
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting $DESC "
+    if running ;  then
+        log_progress_msg "apparently already running"
+        log_end_msg 0
+        exit 0
+    fi
+    if start_server ; then
+        [ -n "$STARTTIME" ] && sleep $STARTTIME # Wait some time
+        if  running ;  then
+            log_end_msg 0
+        else
+            log_end_msg 1
+        fi
+    else
+        log_end_msg 1
+    fi
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC"
+    if running ; then
+      errcode=0
+      stop_server || errcode=$?
+      log_end_msg $errcode
+    else
+      log_progress_msg "apparently not running"
+      log_end_msg 0
+      exit 0
+    fi
+    ;;
+  restart|force-reload)
+    log_daemon_msg "Restarting $DESC"
+    errcode=0
+    reload_server
+    running && errcode=$?
+    log_end_msg $errcode
+    ;;
+  status)
+    log_daemon_msg "Checking status of $DESC"
+    if running ;  then
+      log_progress_msg "running"
+      log_end_msg 0
+    else
+      log_progress_msg "apparently not running"
+      log_end_msg 1
+      exit 3
+    fi
+    ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N {start|stop|restart|status}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0
+

--- a/templates/default/debian/init.d/chef-server.erb
+++ b/templates/default/debian/init.d/chef-server.erb
@@ -1,0 +1,122 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:           chef-server
+# Required-Start:     $remote_fs $network rabbitmq-server couchdb
+# Required-Stop:      $remote_fs $network rabbitmq-server couchdb
+# Default-Start:      2 3 4 5
+# Default-Stop:       0 1 6
+# Short-Description:  Start a chef-server.
+### END INIT INFO
+#
+# Copyright (c) 2009-2010 Opscode, Inc <legal@opscode.com>
+#
+# chef-server         Startup script for chef-server.
+# chkconfig: - 90 02
+# description: starts up chef-server webui.
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=<%= node["chef_server"]["bin_path"] %>/chef-server
+PIDFILE=<%= node["chef_server"]["run_path"] %>/server.%s.pid
+MAINPID=<%= node["chef_server"]["run_path"] %>/server.main.pid
+NAME=chef-server
+DESC=chef-server
+
+test -x $DAEMON || exit 0
+
+. /lib/lsb/init-functions
+
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+if [ ! -d <%= node["chef_server"]["run_path"] %> ]; then
+  mkdir <%= node["chef_server"]["run_path"] %>
+  chown $USER:$GROUP <%= node["chef_server"]["run_path"] %>
+fi
+
+DAEMON_OPTS="-p $PORT -e production -d -a $ADAPTER -P $PIDFILE -L $LOGFILE -C $CONFIG -u $USER -G $GROUP"
+
+running() {
+  [ ! -f  "$MAINPID" ] &&  return 1
+  pid=`cat $MAINPID`
+  [ -z "$pid" ] && return 1
+  [ ! -d /proc/$pid ] && return 1
+  (ps -fp $pid | egrep -q "merb.*(merb : master|worker.*$PORT)") || return 1
+  return 0
+}
+
+start_server() {
+  $DAEMON $DAEMON_OPTS
+  errcode=$?
+  return $errcode
+}
+
+stop_server() {
+  $DAEMON -K all -P $PIDFILE
+  errcode=$?
+  return $errcode
+}
+
+reload_server() {
+  stop_server
+  [ -n "$DIETIME" ] && sleep $DIETIME
+  start_server
+  [ -n "$STARTTIME" ] && sleep $STARTTIME
+}
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting $DESC "
+    if running ;  then
+        log_progress_msg "apparently already running"
+        log_end_msg 0
+        exit 0
+    fi
+    if start_server ; then
+        [ -n "$STARTTIME" ] && sleep $STARTTIME # Wait some time
+        if  running ;  then
+            log_end_msg 0
+        else
+            log_end_msg 1
+        fi
+    else
+        log_end_msg 1
+    fi
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC"
+    if running ; then
+      errcode=0
+      stop_server || errcode=$?
+      log_end_msg $errcode
+    else
+      log_progress_msg "apparently not running"
+      log_end_msg 0
+      exit 0
+    fi
+    ;;
+  restart|force-reload)
+    log_daemon_msg "Restarting $DESC"
+    errcode=0
+    reload_server
+    running && errcode=$?
+    log_end_msg $errcode
+    ;;
+  status)
+    log_daemon_msg "Checking status of $DESC"
+    if running ;  then
+      log_progress_msg "running"
+      log_end_msg 0
+    else
+      log_progress_msg "apparently not running"
+      log_end_msg 1
+      exit 3
+    fi
+    ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N {start|stop|restart|status}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0
+

--- a/templates/default/debian/init.d/chef-solr.erb
+++ b/templates/default/debian/init.d/chef-solr.erb
@@ -1,0 +1,176 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:           chef-solr
+# Required-Start:     $remote_fs $network
+# Required-Stop:      $remote_fs $network
+# Default-Start:      2 3 4 5
+# Default-Stop:       0 1 6
+# Short-Description:  Start a chef-solr.
+### END INIT INFO
+#
+# Copyright (c) 2009-2010 Opscode, Inc <legal@opscode.com>
+#
+# chef-solr         Startup script for chef-solr.
+# chkconfig: - 84 02
+# description: starts up chef-solr in daemon mode.
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=<%= node["chef_server"]["bin_path"] %>/chef-solr
+DAEMON_NAME=java
+NAME=chef-solr
+DESC=chef-solr
+PIDFILE=<%= node["chef_server"]["run_path"] %>/solr.pid
+
+test -x $DAEMON || exit 0
+
+. /lib/lsb/init-functions
+
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+if [ ! -d <%= node["chef_server"]["run_path"] %> ]; then
+  mkdir <%= node["chef_server"]["run_path"] %>
+  chown $USER:$GROUP <%= node["chef_server"]["run_path"] %>
+fi
+
+if [ ! -f $LOGFILE ]; then
+  touch $LOGFILE
+  chown $USER:$GROUP $LOGFILE
+fi
+
+DAEMON_OPTS="-d -P $PIDFILE -c $CONFIG -L $LOGFILE -u $USER -g $GROUP"
+
+running_pid() {
+  pid=$1
+  name=$2
+  [ -z "$pid" ] && return 1
+  [ ! -d /proc/$pid ] &&  return 1
+  cmd=`cat /proc/$pid/cmdline | tr '\000' '\n' | head -1`
+  [ "$cmd" != "$name" ] &&  return 1
+  return 0
+}
+
+running() {
+  [ ! -f "$PIDFILE" ] && return 1
+  pid=`cat $PIDFILE`
+  running_pid $pid $DAEMON_NAME || return 1
+  return 0
+}
+
+start_server() {
+  start_daemon -p $PIDFILE $DAEMON $DAEMON_OPTS
+  errcode=$?
+  for i in `seq 0 $MAXTRIES`
+  do
+    if running; then
+      errcode=0
+      break
+    else
+      [ -n "$STARTTIME" ] && sleep $STARTTIME
+    fi
+  done
+  return $errcode
+}
+
+stop_server() {
+   killproc -p $PIDFILE $DAEMON
+   errcode=$?
+   return $errcode
+}
+
+reload_server() {
+  [ ! -f "$PIDFILE" ] && return 1
+  pid=pidofproc $PIDFILE # This is the daemon's pid
+  /bin/kill -1 $pid
+  return $?
+}
+
+force_stop() {
+  [ ! -e "$PIDFILE" ] && return
+  if running ; then
+    /bin/kill -15 $pid
+    sleep "$DIETIME"s
+    if running ; then
+      /bin/kill -9 $pid
+      sleep "$DIETIME"s
+      if running ; then
+        echo "Cannot kill $NAME (pid=$pid)!"
+        exit 1
+      fi
+    fi
+  fi
+  rm -f $PIDFILE
+}
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting $DESC " "$NAME"
+    if running ;  then
+        log_progress_msg "apparently already running"
+        log_end_msg 0
+        exit 3
+    fi
+    if start_server ; then
+        [ -n "$STARTTIME" ] && sleep $STARTTIME # Wait some time
+        if  running ;  then
+            log_end_msg 0
+        else
+            log_end_msg 1
+        fi
+    else
+        log_end_msg 1
+    fi
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC" "$NAME"
+    if running ; then
+      errcode=0
+      stop_server || errcode=$?
+      log_end_msg $errcode
+    else
+      log_progress_msg "apparently not running"
+      log_end_msg 0
+      exit 0
+    fi
+    ;;
+  force-stop)
+    $0 stop
+    if running; then
+      log_daemon_msg "Stopping (force) $DESC" "$NAME"
+      errcode=0
+      force_stop || errcode=$?
+      log_end_msg $errcode
+    fi
+    ;;
+  restart|force-reload)
+    log_daemon_msg "Restarting $DESC" "$NAME"
+    errcode=0
+    stop_server || errcode=$?
+    [ -n "$DIETIME" ] && sleep $DIETIME
+    start_server || errcode=$?
+    [ -n "$STARTTIME" ] && sleep $STARTTIME
+    running || errcode=$?
+    log_end_msg $errcode
+    ;;
+  status)
+    log_daemon_msg "Checking status of $DESC" "$NAME"
+    if running ;  then
+      log_progress_msg "running"
+      log_end_msg 0
+    else
+      log_progress_msg "apparently not running"
+      log_end_msg 1
+      exit 1
+    fi
+    ;;
+  reload)
+    log_warning_msg "Reloading $NAME daemon: not implemented, as the daemon"
+    log_warning_msg "cannot re-read the config file (use restart)."
+    ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N {start|stop|force-stop|restart|force-reload|status}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/templates/default/redhat/init.d/chef-expander.erb
+++ b/templates/default/redhat/init.d/chef-expander.erb
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# chef-expander Startup script for the Chef search indexer
+#
+# chkconfig: - 95 05
+# description: Search indexer component of the Chef Server.
+
+### BEGIN INIT INFO
+# Provides: chef-expander
+# Required-Start: $local_fs $network $remote_fs chef-solr rabbitmq-server
+# Required-Stop: $local_fs $network $remote_fs chef-solr rabbitmq-server
+# Should-Start: $named $time
+# Should-Stop: $named $time
+# Short-Description: Startup script for the Chef search indexer
+# Description: Search indexer component of the Chef Server.
+### END INIT INFO
+
+# Source function library
+. /etc/init.d/functions
+
+exec="<%= node["chef_server"]["bin_path"] %>/chef-expander"
+prog="chef-expander"
+
+[ -f /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+config=${CONFIG-/etc/chef/expander.rb}
+pidfile=${PIDFILE-<%= node["chef_server"]["run_path"] %>/expander.pid}
+lockfile=${LOCKFILE-/var/lock/subsys/$prog}
+logfile=${LOGFILE-/var/log/chef/expander.log}
+options=${OPTIONS-}
+
+start() {
+    [ -x $exec ] || exit 5
+    [ -f $config ] || exit 6
+    echo -n $"Starting $prog: "
+    daemon $prog -d -c "$config" -L "$logfile" -P "$pidfile" "$options"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc -p $pidfile $prog
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart () {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    # run checks to determine if the service is running or use generic status
+    status -p $pidfile $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+        exit 2
+esac
+exit $?

--- a/templates/default/redhat/init.d/chef-server-webui.erb
+++ b/templates/default/redhat/init.d/chef-server-webui.erb
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# chef-server-webui Startup script for chef-server-webui
+#
+# chkconfig: - 97 03
+# description: Server WebUI component of the Chef systems integration framework.
+
+### BEGIN INIT INFO
+# Provides: chef-server-webui
+# Required-Start: $local_fs $network $remote_fs chef-sever
+# Required-Stop: $local_fs $network $remote_fs chef-server
+# Should-Start: $named $time
+# Should-Stop: $named $time
+# Short-Description: Startup script for chef-server-webui 
+# Description: Server WebUI component of the Chef systems integration framework.
+### END INIT INFO
+
+# Source function library
+. /etc/init.d/functions
+
+exec="<%= node["chef_server"]["bin_path"] %>/chef-server-webui"
+prog="chef-server-webui"
+
+[ -f /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+config=${CONFIG-/etc/chef/webui.rb}
+pidfile=${PIDFILE-<%= node["chef_server"]["run_path"] %>/server-webui.main.pid}
+lockfile=${LOCKFILE-/var/lock/subsys/$prog}
+logfile=${LOGFILE-/var/log/chef/server-webui.log}
+port=${PORT-4040}
+env=${ENVIRONMENT-production}
+adapter=${ADAPTER-thin}
+childpidfiles=${CHILDPIDFILES-<%= node["chef_server"]["run_path"] %>/server-webui.%s.pid}
+user=${SERVER_USER-chef}
+group=${SERVER_GROUP-chef}
+options=${OPTIONS-}
+
+start() {
+    [ -x $exec ] || exit 5
+    [ -f $config ] || exit 6
+    echo -n $"Starting $prog: "
+    daemon $prog -d -C "$config" -L "$logfile" -p "$port" -e "$env" \
+                 -a "$adapter" -P "$childpidfiles" -u "$user" -G "$group" \
+                 "$options" "&>/dev/null"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc -p $pidfile $prog 
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart () {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    # run checks to determine if the service is running or use generic status
+    status -p $pidfile $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+        exit 2
+esac
+exit $?

--- a/templates/default/redhat/init.d/chef-server.erb
+++ b/templates/default/redhat/init.d/chef-server.erb
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# chef-server Startup script for chef-server
+#
+# chkconfig: - 96 04
+# description: Server component of the Chef systems integration framework.
+
+### BEGIN INIT INFO
+# Provides: chef-server
+# Required-Start: $local_fs $network $remote_fs chef-solr chef-expander
+# Required-Stop: $local_fs $network $remote_fs chef-solr chef-expander
+# Should-Start: $named $time
+# Should-Stop: $named $time
+# Short-Description: Startup script for chef-server 
+# Description: Server component of the Chef systems integration framework.
+### END INIT INFO
+
+# Source function library
+. /etc/init.d/functions
+
+exec="<%= node["chef_server"]["bin_path"] %>/chef-server"
+prog="chef-server"
+
+[ -f /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+config=${CONFIG-/etc/chef/server.rb}
+pidfile=${PIDFILE-<%= node["chef_server"]["run_path"] %>/server.main.pid}
+lockfile=${LOCKFILE-/var/lock/subsys/$prog}
+logfile=${LOGFILE-/var/log/chef/server.log}
+port=${PORT-4000}
+env=${ENVIRONMENT-production}
+adapter=${ADAPTER-thin}
+childpidfiles=${CHILDPIDFILES-<%= node["chef_server"]["run_path"] %>/server.%s.pid}
+user=${SERVER_USER-chef}
+group=${SERVER_GROUP-chef}
+options=${OPTIONS-}
+
+start() {
+    [ -x $exec ] || exit 5
+    [ -f $config ] || exit 6
+    echo -n $"Starting $prog: "
+    daemon $prog -d -C "$config" -L "$logfile" -p "$port" -e "$env" \
+                 -a "$adapter" -P "$childpidfiles" -u "$user" -G "$group" \
+                 "$options" "&>/dev/null"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc -p $pidfile $prog 
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart () {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    # run checks to determine if the service is running or use generic status
+    status -p $pidfile $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+        exit 2
+esac
+exit $?

--- a/templates/default/redhat/init.d/chef-solr.erb
+++ b/templates/default/redhat/init.d/chef-solr.erb
@@ -1,0 +1,104 @@
+#!/bin/bash
+# 
+# chef-solr Startup script for the SOLR search engine
+#
+# chkconfig: - 94 06
+# description: SOLR search engine for the Chef Server.
+
+### BEGIN INIT INFO
+# Provides: chef-solr
+# Required-Start: $local_fs $network $remote_fs
+# Required-Stop: $local_fs $network $remote_fs
+# Should-Start: $named $time
+# Should-Stop: $named $time
+# Short-Description: Startup script for the SOLR search engine
+# Description: SOLR search engine for the Chef Server.
+### END INIT INFO
+
+# Source function library
+. /etc/init.d/functions
+
+exec="<%= node["chef_server"]["bin_path"] %>/chef-solr"
+prog="chef-solr"
+
+[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+config=${CONFIG-/etc/chef/solr.rb}
+pidfile=${PIDFILE-<%= node["chef_server"]["run_path"] %>/solr.pid}
+lockfile=${LOCKFILE-/var/lock/subsys/$prog}
+logfile=${LOGFILE-/var/log/chef/solr.log}
+options=${OPTIONS-}
+
+start() {
+    [ -x $exec ] || exit 5
+    [ -f $config ] || exit 6
+    echo -n $"Starting $prog: "
+    daemon $prog -d -c "$config" -L "$logfile" -P "$pidfile" "$options"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc -p $pidfile $prog 
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart () {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    # run checks to determine if the service is running or use generic status
+    status -p $pidfile $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+        exit 2
+esac
+exit $?


### PR DESCRIPTION
I've pulled in the init scripts from chef/distro and templated them in a similar way as done in the chef-client cookbook. This change only affects debian and redhat like distributions.
