### PR TITLE
COOK-974 - removed hard-coded apache listen_ports, ensure attributes are...

### DIFF
--- a/recipes/apache-proxy.rb
+++ b/recipes/apache-proxy.rb
@@ -23,9 +23,9 @@ root_group = value_for_platform(
   "default" => "root"
 )
 
-node['apache']['listen_ports'] << "443" unless node['apache']['listen_ports'].include?("443")
+node['apache']['listen_ports'] << node['chef_server']['proxy']['api_port'] unless node['apache']['listen_ports'].include?(node['chef_server']['proxy']['api_port'])
 if node['chef_server']['webui_enabled']
-  node['apache']['listen_ports'] << "444" unless node['apache']['listen_ports'].include?("444")
+  node['apache']['listen_ports'] << node['chef_server']['proxy']['webui_port'] unless node['apache']['listen_ports'].include?(node['chef_server']['proxy']['webui_port'])
 end
 
 include_recipe "apache2"


### PR DESCRIPTION
As it's possible to define on which ports should apache start virtual hosts for proxy to chef-server/chef-server-webui, it is required to update apache listen_ports too. 
This is a fix for it. 
