### PR TITLE
COOK-1643: Add Erlang to the metadata as a requirement since the RabbitMQ recipe in...

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The chef-server cookbook requires the following cookbooks from Opscode. Some are
 * daemontools
 * ucspi-tcp
 * build-essential
+* erlang
 
 ATTRIBUTES
 ==========

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,6 @@ recipe            "chef-server::nginx-proxy", "Configures NGINX proxy for API an
   supports os
 end
 
-%w{ runit bluepill daemontools couchdb apache2 nginx openssl zlib xml java gecode }.each do |cb|
+%w{ runit bluepill daemontools couchdb apache2 nginx openssl zlib xml java gecode erlang }.each do |cb|
   depends cb
 end


### PR DESCRIPTION
...cludes it
