### PR TITLE
COOK-1667

### DIFF
--- a/recipes/rubygems-install.rb
+++ b/recipes/rubygems-install.rb
@@ -46,6 +46,8 @@ when "ubuntu"
   include_recipe "chef-server::rabbitmq"
   include_recipe "gecode"
 
+  package "g++-multilib"
+
 when "debian"
   if node['platform_version'].to_f >= 6.0 || node['platform_version'] =~ /.*sid/
     include_recipe "couchdb"


### PR DESCRIPTION
Added a package statement to install g++-multilib on Ubuntu machines, to fix a problem bootstrapping chef-server. I have tested it on Ubuntu 12.04, but haven't tested on other versions to ensure it doesn't cause issues with them (e.g. maybe that package doesn't exist, has been renamed, etc.)
