### PR TITLE
COOK-1983: Support gempaths of rbenv

### DIFF
--- a/templates/default/sv-chef-expander-run.erb
+++ b/templates/default/sv-chef-expander-run.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
-PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin<% if node['languages']['ruby']['gems_dir'] %>:<%= node['languages']['ruby']['gems_dir'] %>/bin<% end -%>
+#!/bin/bash
+PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin<% if node['languages']['ruby']['bin_dir'] %>:<%= node['languages']['ruby']['bin_dir'] %><% end -%>
 exec 2>&1
 exec /usr/bin/env chef-expander -n <%= node['chef_server']['expander_nodes'] %>

--- a/templates/default/sv-chef-server-run.erb
+++ b/templates/default/sv-chef-server-run.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
-PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin<% if node['languages']['ruby']['gems_dir'] %>:<%= node['languages']['ruby']['gems_dir'] %>/bin<% end -%>
+#!/bin/bash
+PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin<% if node['languages']['ruby']['bin_dir'] %>:<%= node['languages']['ruby']['bin_dir'] %><% end -%>
 exec 2>&1
 exec /usr/bin/env chef-server -N -p <%= node['chef_server']['api_port'] %> -e production -P <%= node['chef_server']['run_path'] %>/server.%s.pid

--- a/templates/default/sv-chef-server-webui-run.erb
+++ b/templates/default/sv-chef-server-webui-run.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
-PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin<% if node['languages']['ruby']['gems_dir'] %>:<%= node['languages']['ruby']['gems_dir'] %>/bin<% end -%>
+#!/bin/bash
+PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin<% if node['languages']['ruby']['bin_dir'] %>:<%= node['languages']['ruby']['bin_dir'] %><% end -%>
 exec 2>&1
 exec /usr/bin/env chef-server-webui -N -p <%= node['chef_server']['webui_port'] %> -e production -P <%= node['chef_server']['run_path'] %>/server-webui.%s.pid

--- a/templates/default/sv-chef-solr-run.erb
+++ b/templates/default/sv-chef-solr-run.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
-PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin<% if node['languages']['ruby']['gems_dir'] %>:<%= node['languages']['ruby']['gems_dir'] %>/bin<% end -%>
+#!/bin/bash
+PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin<% if node['languages']['ruby']['bin_dir'] %>:<%= node['languages']['ruby']['bin_dir'] %><% end -%>
 exec 2>&1
 exec /usr/bin/env chef-solr


### PR DESCRIPTION
This fixes [COOK-1983](http://tickets.opscode.com/browse/COOK-1983) by using the `node['languages']['ruby']['bin_path']` in runit run templates.
