### PR TITLE
COOK-1974 set service init priority for chef-server services

### DIFF
--- a/recipes/rubygems-install.rb
+++ b/recipes/rubygems-install.rb
@@ -218,6 +218,9 @@ when "init"
     service svc do
       supports :status => true
       action [ :enable, :start ]
+      if platform_family?("debian")
+        priority("2 3 4 5" => [ "start", "19" ], "0 1 6" => [ "stop", "81" ])
+      end
     end
   end
 


### PR DESCRIPTION
This makes sure that chef-expander, chef-solr and chef-server start before the chef-client service.

That way after a server reboot the /var/run/chef directory will be created with chef:chef ownership allowing chef-solr to start correctly.

I added a platform_family test since only Chef::Provider::Service::Debian supports priority at this time.
