### PR TITLE
CouchDB compaction fix

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,6 +31,7 @@ end
 http_request "compact chef couchDB" do
   action :post
   url "#{Chef::Config[:couchdb_url]}/chef/_compact"
+  headers("Content-Type" => "application/json")
   only_if do
     begin
       open("#{Chef::Config[:couchdb_url]}/chef")
@@ -46,6 +47,7 @@ end
   http_request "compact chef couchDB view #{view}" do
     action :post
     url "#{Chef::Config[:couchdb_url]}/chef/_compact/#{view}"
+    headers("Content-Type" => "application/json")
     only_if do
       begin
         open("#{Chef::Config[:couchdb_url]}/chef/_design/#{view}/_info")


### PR DESCRIPTION
This applies to the chef10 branch and solves two issues.

If you have a couchdb that's not on the server running chef itself, it's very unlikely that `couchdb_url` is in the Chef::Config -- and is defaulted to localhost.

This solution tries to avoid a split brain by just loading server.rb if it exists and then loading client.rb again so we don't confuse chef-client.

It also resolves another issue where couch itself will reject HTTP API requests where the content-type isn't specified, something we noticed on redhat packages for couch.
