### PR TITLE
Update to cookbook to support Vagrant 1.1+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,0 @@
-source :rubygems
-
-gem 'berkshelf'
-gem 'thor-foodcritic'
-gem 'vagrant', '~> 1.0.5'

--- a/README.md
+++ b/README.md
@@ -184,35 +184,50 @@ You would then pass this file to the initial chef-solo command:
 We <3 the wonderful open-source tools
 [Berkshelf](http://berkshelf.com/) and
 [Vagrant](http://vagrantup.com/). You can take Chef Server for a spin
-using the Berksfile and Vagrantfile shipped along side this cookbook.
-The only requirements for standing up a virtualized Chef Server are
-Ruby, Rubygems, and VirtualBox.
+using the Berksfile and Vagrantfile that ship alongside this cookbook.
+The only requirements for standing up a virtualized Chef Server are:
 
-    gem install bundler --no-ri --no-rdoc
-    git clone git://github.com/opscode-cookbooks/chef-server.git
-    cd chef-server
-    bundle install
-    bundle exec vagrant up
+* VirtualBox - native packages exist for most platforms and can be downloaded
+from the [VirtualBox downloads page](https://www.virtualbox.org/wiki/Downloads).
+* Vagrant 1.1+ - native packages exist for most platforms and can be downloaded
+from the [Vagrant downloads page](http://downloads.vagrantup.com/).
 
-If you need help installing any of the prerequisites take a look at
-Jamie Winsor's excellent
-[blog post](http://vialstudios.com/guide-authoring-cookbooks.html) on
-the subject.
+The [berkshelf-vagrant](https://github.com/RiotGames/berkshelf-vagrant) and
+[vagrant-omnibus](https://github.com/schisamo/vagrant-omnibus) Vagrant plugins
+are also required and can be installed easily with the following commands:
+
+```shell
+$ vagrant plugin install berkshelf-vagrant
+$ vagrant plugin install vagrant-omnibus
+```
+
+Once the pre-requisites are installed you can start the virtualized environment
+with the following command:
+
+```shell
+$ vagrant up
+```
+
+Although things have only been tested with Vagrant's `virtualbox` provider
+everything should work with other providers like `vmware_fusion` or `ec2`.
 
 You can easily SSH into the running VM using the `vagrant ssh` command.
 The VM can easily be stopped and deleted with the `vagrant destroy`
-command. Please see the official [Vagrant documentation](http://vagrantup.com/v1/docs/commands.html)
-for a more in depth explanation of available commands.
+command. Please see the official
+[Vagrant documentation](http://vagrantup.com/v1/docs/commands.html) for a more
+in depth explanation of available commands.
 
 The running Chef-Server components are accessible from the host machine
 using the following URLs:
 
-* Web UI: https://33.33.33.50/ (Note: Attempts to hit via straight http will be redirected to the Vagrant guest's internal hostname)
+* Web UI: https://33.33.33.50/ (Note: Attempts to hit via straight http will be
+redirected to the Vagrant guest's internal hostname)
 * Version Manifest: https://33.33.33.50/version
 * Chef Server API (routing requires `X-OPS-USERID` HTTP header being properly
 set): https://33.33.33.50/
 
-*Note: It can be helpful to use the host workstation's /etc/hosts file to map 33.33.33.50 to chef-server-berkshelf.*
+*Note: It can be helpful to use the host workstation's /etc/hosts file to map
+33.33.33.50 to chef-server-berkshelf.*
 
 ## Contribute to and Hack on Chef Server (including Erchef)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,66 +1,45 @@
-require 'berkshelf/vagrant'
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
 
 # We'll mount the Chef::Config[:file_cache_path] so it persists between
 # Vagrant VMs
 host_cache_path = File.expand_path("../.cache", __FILE__)
 guest_cache_path = "/tmp/vagrant-cache"
 
-# ensure the cache path exists
-FileUtils.mkdir(host_cache_path) unless File.exist?(host_cache_path)
+Vagrant.configure("2") do |config|
 
-Vagrant::Config.run do |config|
-  # TODO REMOVE THIS WHEN WE FORCE SMP MODE IN ERCHEF
-  config.vm.customize ["modifyvm", :id, "--cpus", 2]
-  config.vm.customize ["modifyvm", :id, "--memory", 1024]
-  # All Vagrant configuration is done here. The most common configuration
-  # options are documented and commented below. For a complete reference,
-  # please see the online documentation at vagrantup.com.
+  config.vm.hostname = "chef-server"
 
-  # The path to the Berksfile to use with Vagrant Berkshelf
-  # config.berkshelf.berksfile_path = "./Berksfile"
+  config.vm.box = "canonical-ubuntu-12.04"
+  config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box"
+  # config.vm.box = "opscode-ubuntu-10.04"
+  # config.vm.box_url = "http://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_chef-11.2.0.box"
+  # config.vm.box = "opscode-centos-6.3"
+  # config.vm.box_url = "http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.3_chef-11.2.0.box"
 
-  # An array of symbols representing groups of cookbook described in the Vagrantfile
-  # to skip installing and copying to Vagrant's shelf.
-  # config.berkshelf.only = []
+  # Ensure Chef is installed for provisioning
+  config.omnibus.chef_version = "11.4.0"
 
-  # An array of symbols representing groups of cookbook described in the Vagrantfile
-  # to skip installing and copying to Vagrant's shelf.
-  # config.berkshelf.except = []
+  config.vm.network :private_network, :ip => "33.33.33.50"
 
-  config.vm.host_name = "chef-server-berkshelf"
-
-  config.vm.box = "opscode-ubuntu-12.04"
-  config.vm.box_url = "https://opscode-vm.s3.amazonaws.com/vagrant/boxes/opscode-ubuntu-12.04.box"
-
-  # Boot with a GUI so you can see the screen. (Default is headless)
-  # config.vm.boot_mode = :gui
-
-  # Assign this VM to a host-only network IP, allowing you to access it
-  # via the IP. Host-only networks can talk to the host machine as well as
-  # any other machines on the same network, but cannot be accessed (through this
-  # network interface) by any external networks.
-  config.vm.network :hostonly, "33.33.33.50"
-
-  # Assign this VM to a bridged network, allowing you to connect directly to a
-  # network using the host's network device. This makes the VM appear as another
-  # physical device on your network.
-
-  # config.vm.network :bridged
-
-  # Forward a port from the guest to the host, which allows for outside
-  # computers to access the VM, whereas host only networking does not.
-  # config.vm.forward_port 80, 8080
-
-  # Share an additional folder to the guest VM. The first argument is
-  # an identifier, the second is the path on the guest to mount the
-  # folder, and the third is the path on the host to the actual folder.
-  config.vm.share_folder "cache", guest_cache_path, host_cache_path
+  config.vm.provider :virtualbox do |vb|
+    # Give enough horsepower to build without taking all day.
+    vb.customize [
+      "modifyvm", :id,
+      "--memory", "1024",
+      "--cpus", "2",
+    ]
+  end
 
   config.ssh.max_tries = 40
   config.ssh.timeout   = 120
-
   # Enable SSH agent forwarding for git clones
   config.ssh.forward_agent = true
+
+  # The path to the Berksfile to use with Vagrant Berkshelf
+  config.berkshelf.berksfile_path = "./Berksfile"
+
+  config.vm.synced_folder host_cache_path, guest_cache_path
 
   config.vm.provision :chef_solo do |chef|
     chef.provisioning_path = guest_cache_path
@@ -74,5 +53,4 @@ Vagrant::Config.run do |config|
       "recipe[chef-server::default]"
     ]
   end
-
 end


### PR DESCRIPTION
Vagrant 1.1+ is now installed system-wide so the Bundler requirement
(and associated Gemfile) have been removed! The README has been
updated to reflect new demo/dev environment installation and usage
instructions.
