### PR TITLE
[COOK-3718] ignore FC009 on this line is triggered by a known bug in foodcritic.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,7 +52,7 @@ else
 end
 
 # install the platform package
-package package_name do
+package package_name do # ignore ~FC009 known bug in food critic causes this to trigger see Foodcritic Issue #137
   source package_local_path
   provider case node["platform_family"]
            when "debian"; Chef::Provider::Package::Dpkg


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3718

Foodcritic is incorrectly flagging a raise method as an attribtue as on the package resource.   This is a known issue documented in Foodcritic #137 (https://github.com/acrmp/foodcritic/issues/137).

This is a known failure in the linting tool itself rather than the chef-server cookbook, lets avoid unnecessary failures by adding an inline ignore for FC009 on this line.
