### PR TITLE
[COOK-4176] Ensure creation of `:file_cache_path`

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,6 +35,14 @@ end
 package_name = ::File.basename(omnibus_package)
 package_local_path = "#{Chef::Config[:file_cache_path]}/#{package_name}"
 
+# Ensure :file_cache_path exists
+directory Chef::Config[:file_cache_path] do
+  owner "root"
+  group "root"
+  recursive true
+  action :create
+end
+
 # omnibus_package is remote (ie a URI) let's download it
 if ::URI.parse(omnibus_package).absolute?
   remote_file package_local_path do


### PR DESCRIPTION
Fix to ensure that the file cache path exists. An error occurs while testing the recipe with Vagrant, which was narrowed to the path not existing when downloading the the chef-server remote package (`package_name`). The path created has proper permissions, and relies on Chef's config hash value for the path.
