### PR TITLE
Reconfigure chef server after upgrading

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,6 +61,7 @@ package package_name do # ignore ~FC009 known bug in food critic causes this to 
             raise RuntimeError("I don't know how to install chef-server packages for platform family '#{node["platform_family"]}'!")
            end
   action :install
+  notifies :run, "execute[reconfigure-chef-server]"
 end
 
 # create the chef-server etc directory


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4125

This triggers a `chef-server-ctl reconfigure` after upgrading Chef Server using the chef-server cookbook.
