### PR TITLE
Vagrantfile can't find vagrant-omnibus correctly

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure('2') do |config|
   end
 
   # Detects vagrant-omnibus plugin
-  if Vagrant.has_plugin?('Omnibus')
+  if Vagrant.has_plugin?('vagrant-omnibus')
     puts 'INFO:  Vagrant-omnibus plugin detected.'
     config.omnibus.chef_version = :latest
   else


### PR DESCRIPTION
Changed the `.has_plugin?` to use the correct string to detect `vagrant-omnibus`.
