### PR TITLE
Fixes #74, use reconfigure action

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,7 @@ suites:
   run_list:
   - recipe[test]
   - recipe[chef-server]
+  - recipe[test::post-install]
   attributes:
     chef-server:
       api_fqdn: 'chef-server-tk.example.com'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@ require 'resolv'
 
 chef_server_ingredient 'chef-server-core' do
   version node['chef-server']['version']
-  notifies :reconfigure, 'chef_server_ingredient[chef-server-core]'
+  action [:install, :reconfigure]
 end
 
 directory '/etc/opscode' do

--- a/test/fixtures/cookbooks/test/recipes/post-install.rb
+++ b/test/fixtures/cookbooks/test/recipes/post-install.rb
@@ -1,0 +1,9 @@
+execute 'create-admin-user' do
+  command 'chef-server-ctl user-create exemplar "Example User" exemplar@example.com dontusethisforreal --filename /tmp/exemplar.key'
+  not_if 'chef-server-ctl user-list | grep "exemplar"'
+end
+
+execute 'create-organization' do
+  command 'chef-server-ctl org-create sample "Sample Size" --association_user exemplar --filename /tmp/exemplar.key'
+  not_if 'chef-server-ctl org-list | grep "sample"'
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -18,4 +18,14 @@ describe 'chef-server' do
   describe command('chef-server-ctl test') do
     its(:exit_status) { should eq 0 }
   end
+
+  describe command('chef-server-ctl org-list') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(/sample/) }
+  end
+
+  describe command('chef-server-ctl list-user-keys exemplar') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(/1 total key\(s\) found for user exemplar/) }
+  end
 end


### PR DESCRIPTION
Instead of notifying that the ingredient should reconfigure, we should
use the reconfigure action in the default recipe. It's important to
note that while this is idempotent, but it is not convergent, and will run
every time chef-client runs on the Chef Server.

Also add a recipe to create a user and org, and serverspec to test
they exist.

```
Command "chef-server-ctl org-list"
  exit_status
    should eq 0
  stdout
    should match /sample/
Command "chef-server-ctl list-user-keys exemplar"
  exit_status
    should eq 0
  stdout
    should match /1 total key\(s\) found for user exemplar/
```

@luckymike @stephenlauck