### PR TITLE
Add org and user

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,12 +8,8 @@ provisioner:
   name: chef_zero
 
 platforms:
-- name: ubuntu-10.04
-- name: ubuntu-12.04
 - name: ubuntu-14.04
 - name: centos-6.6
-- name: centos-5.10
-- name: centos-5.11
 
 suites:
 - name: default

--- a/libraries/chef_server_org_provider.rb
+++ b/libraries/chef_server_org_provider.rb
@@ -1,0 +1,41 @@
+require 'chef/provider/lwrp_base'
+
+class Chef
+  class Provider
+    class ChefServerOrg < Chef::Provider::LWRPBase
+
+      use_inline_resources if defined?(use_inline_resources)
+
+      def whyrun_supported?
+        true
+      end
+
+      action :create do
+        execute 'create org' do
+          command <<-EOM.gsub(/\s+/, ' ').strip!
+            chef-server-ctl org-create #{new_resource.org_name}
+            #{new_resource.org_long_name}
+            -f #{new_resource.org_private_key_path}
+          EOM
+          not_if "chef-server-ctl org-list | grep -w #{new_resource.org_name}"
+        end
+      end
+
+      action :delete do
+        # delete org
+      end
+
+      action :add_admin do
+        new_resource.admins.each do |admin|
+          execute 'add users to org' do
+            command <<-EOM.gsub(/\s+/, ' ').strip!
+              chef-server-ctl org-user-add #{new_resource.org_name} #{admin}
+              --admin
+            EOM
+            # not_if "chef-server-ctl org-list | grep -w #{new_resource.org_name}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/libraries/chef_server_org_resource.rb
+++ b/libraries/chef_server_org_resource.rb
@@ -1,0 +1,16 @@
+require 'chef/resource/lwrp_base'
+
+class Chef
+  class Resource
+    class ChefServerOrg < Chef::Resource::LWRPBase
+      self.resource_name = :chef_server_org
+      actions :create, :delete, :add_admin
+      default_action :create
+
+      attribute :org_name, kind_of: String, name_attribute: true, required: true
+      attribute :org_long_name, kind_of: String, default: nil
+      attribute :org_private_key_path, kind_of: String, default: nil
+      attribute :admins, kind_of: [String, Array], default: nil
+    end
+  end
+end

--- a/libraries/chef_server_user_provider.rb
+++ b/libraries/chef_server_user_provider.rb
@@ -1,0 +1,32 @@
+require 'chef/provider/lwrp_base'
+
+class Chef
+  class Provider
+    class ChefServerUser < Chef::Provider::LWRPBase
+
+      use_inline_resources if defined?(use_inline_resources)
+
+      def whyrun_supported?
+        true
+      end
+
+      action :create do
+        execute 'create user' do
+          command <<-EOM.gsub(/\s+/, ' ').strip!
+            chef-server-ctl user-create #{new_resource.username}
+            #{new_resource.firstname}
+            #{new_resource.lastname}
+            #{new_resource.email}
+            #{new_resource.password}
+            -f #{new_resource.private_key_path}
+          EOM
+          not_if "chef-server-ctl user-list | grep -w #{new_resource.username}"
+        end
+      end
+
+      action :delete do
+        # delete user
+      end
+    end
+  end
+end

--- a/libraries/chef_server_user_resource.rb
+++ b/libraries/chef_server_user_resource.rb
@@ -1,0 +1,18 @@
+require 'chef/resource/lwrp_base'
+
+class Chef
+  class Resource
+    class ChefServerUser < Chef::Resource::LWRPBase
+      self.resource_name = :chef_server_user
+      actions :create, :delete
+      default_action :create
+
+      attribute :username, kind_of: String, name_attribute: true, required: true
+      attribute :firstname, kind_of: String, default: nil
+      attribute :lastname, kind_of: String, default: nil
+      attribute :email, kind_of: String, default: nil
+      attribute :password, kind_of: String, default: nil
+      attribute :private_key_path, kind_of: String, default: nil
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/post-install.rb
+++ b/test/fixtures/cookbooks/test/recipes/post-install.rb
@@ -1,9 +1,19 @@
-execute 'create-admin-user' do
-  command 'chef-server-ctl user-create exemplar "Example User" exemplar@example.com dontusethisforreal --filename /tmp/exemplar.key'
-  not_if 'chef-server-ctl user-list | grep "exemplar"'
+chef_server_user 'testuser' do
+  firstname 'Test'
+  lastname 'User'
+  email 'testuser@example.com'
+  password 'testuser'
+  private_key_path '/tmp/testuser.pem'
+  action :create
 end
 
-execute 'create-organization' do
-  command 'chef-server-ctl org-create sample "Sample Size" --association_user exemplar --filename /tmp/exemplar.key'
-  not_if 'chef-server-ctl org-list | grep "sample"'
+chef_server_org 'example' do
+  org_long_name 'Example Organization'
+  org_private_key_path '/tmp/example-validator.pem'
+  action :create
+end
+
+chef_server_org 'example' do
+  admins %w{ testuser }
+  action :add_admin
 end


### PR DESCRIPTION
I think an LWRP wrapping chef-server-ctl to create a minimum/default org and user is a super useful thing to have in this cookbook. I've replaced the manual calls to chef-server-ctl in the test cookbook post-install also.