### PR TITLE
Use Cheffish resources for user and org creation

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,11 +29,6 @@ chef_server_ingredient 'chef-server-core' do
   action :install
 end
 
-file "#{cache_path}/chef-server-core.firstrun" do
-  action :create
-  notifies :reconfigure, 'chef_server_ingredient[chef-server-core]', :immediately
-end
-
 directory '/etc/opscode' do
   owner 'root'
   group 'root'

--- a/test/fixtures/cookbooks/test/recipes/post-install.rb
+++ b/test/fixtures/cookbooks/test/recipes/post-install.rb
@@ -1,9 +1,64 @@
-execute 'create-admin-user' do
-  command 'chef-server-ctl user-create exemplar "Example User" exemplar@example.com dontusethisforreal --filename /tmp/exemplar.key'
-  not_if 'chef-server-ctl user-list | grep "exemplar"'
+# we need to ensure that the reconfigure is run so that the api_fqdn
+# is updated for the correct chef_server_url we're using from the
+# attribute defined in .kitchen.yml.
+execute 'chef-server-ctl reconfigure'
+
+chef_server_opts = {
+                    chef_server_url: 'https://chef-server-tk.example.com',
+                    options: {
+                      client_name: 'pivotal',
+                      signing_key_filename: '/etc/opscode/pivotal.pem'
+                    }
+                   }
+
+# Begin: Cheffish from GitHub pull request
+# https://github.com/chef/cheffish/pull/50
+# Once that PR is merged we can just do chef_gem 'cheffish' with a
+# version pin.
+execute 'apt-get update' if platform_family?('debian')
+
+package('git') do
+  # TODO: Drop this when we no longer support Ubuntu 10.04 (it's EOL)
+  package_name 'git-core' if platform?('ubuntu') && node['platform_version'].to_f == 10.04
+end.run_action :install
+
+git '/tmp/cheffish' do
+  repository 'https://github.com/chef/cheffish'
+  branch 'ssd/organization-force-associate'
+end.run_action :checkout
+
+execute "#{Chef::Config.embedded_dir}/bin/rake build" do
+  cwd '/tmp/cheffish'
+  creates '/tmp/cheffish/pkg/cheffish-1.2.gem'
+end.run_action :run
+
+chef_gem 'cheffish' do
+  source '/tmp/cheffish/pkg/cheffish-1.2.gem'
+  compile_time true
+end
+# End: Cheffish from GitHub pull request
+
+require 'cheffish'
+
+directory Chef::Config[:trusted_certs_dir] do
+  recursive true
 end
 
-execute 'create-organization' do
-  command 'chef-server-ctl org-create sample "Sample Size" --association_user exemplar --filename /tmp/exemplar.key'
-  not_if 'chef-server-ctl org-list | grep "sample"'
+link File.join(Chef::Config[:trusted_certs_dir], 'chef-server-tk.example.com.crt') do
+  to '/var/opt/opscode/nginx/ca/chef-server-tk.example.com.crt'
+end
+
+private_key '/tmp/exemplar.key'
+
+chef_user 'exemplar' do
+  email 'exemplar@example.com'
+  password 'dontusethisforreal'
+  source_key_path '/tmp/exemplar.key'
+  chef_server chef_server_opts
+end
+
+chef_organization 'sample' do
+  full_name 'Sample Size'
+  members ['exemplar']
+  chef_server chef_server_opts
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -26,6 +26,6 @@ describe 'chef-server' do
 
   describe command('chef-server-ctl list-user-keys exemplar') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/1 total key\(s\) found for user exemplar/) }
+    its(:stdout) { should match(/name: default/) }
   end
 end


### PR DESCRIPTION
As part of a larger effort to make use of our own primitives, the
test::post-install recipe should use Cheffish chef_user and
chef_organization resources to create the example user and organization.

It may be many more lines of code, but at the end of the day it is
declarative, and these resources are inherently both convergent and
idempotent. Running the chef-server-ctl commands requires a guard, which
parses output that can change more easily in a user-facing tool. The
Cheffish resources use the REST API of the Chef Server, and changes to
the API itself is made with far more consideration.

That said, there's a bug in the Cheffish chef_organization resource,
addressed by the following pull request:

https://github.com/chef/cheffish/pull/50

As such, we install the Cheffish gem built from the branch in that PR.
When that is merged and a new Cheffish gem is released, then we can
remove the git and rake use in the recipe, and just use chef_gem.