### PR TITLE
Use chef-ingredient cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,12 +8,11 @@ provisioner:
   name: chef_zero
 
 platforms:
-- name: ubuntu-10.04
 - name: ubuntu-12.04
 - name: ubuntu-14.04
 - name: centos-6.6
-- name: centos-5.10
 - name: centos-5.11
+- name: centos-7.1
 
 suites:
 - name: default
@@ -48,4 +47,4 @@ suites:
     chef-server:
       api_fqdn: ''
       addons:
-        - opscode-manage
+        - manage

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description 'Installs and configures Chef Server 12'
 source_url 'https://github.com/chef-cookbooks/chef-server'
 issues_url 'https://github.com/chef-cookbooks/chef-server/issues'
 
-depends 'chef-server-ingredient'
+depends 'chef-ingredient', '>= 0.7.0'
 
 supports 'centos'
 supports 'ubuntu'

--- a/recipes/addons.rb
+++ b/recipes/addons.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 node['chef-server']['addons'].each do |addon|
-  chef_server_ingredient addon do
-    notifies :reconfigure, "chef_server_ingredient[#{addon}]"
+  chef_ingredient addon do
+    notifies :reconfigure, "chef_ingredient[#{addon}]"
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ ruby_block 'ensure node can resolve API FQDN' do
   not_if { api_fqdn_resolves }
 end
 
-chef_server_ingredient 'chef-server-core' do
+chef_ingredient 'chef-server' do
   version node['chef-server']['version']
   package_source node['chef-server']['package_source']
   action :install
@@ -32,7 +32,7 @@ end
 
 file "#{cache_path}/chef-server-core.firstrun" do
   action :create
-  notifies :reconfigure, 'chef_server_ingredient[chef-server-core]', :immediately
+  notifies :reconfigure, 'chef_ingredient[chef-server]', :immediately
 end
 
 directory '/etc/opscode' do
@@ -49,5 +49,5 @@ template '/etc/opscode/chef-server.rb' do
   owner 'root'
   group 'root'
   action :create
-  notifies :reconfigure, 'chef_server_ingredient[chef-server-core]', :immediately
+  notifies :reconfigure, 'chef_ingredient[chef-server]', :immediately
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -26,6 +26,6 @@ describe 'chef-server' do
 
   describe command('chef-server-ctl list-user-keys exemplar') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/1 total key\(s\) found for user exemplar/) }
+    its(:stdout) { should match(/name: default\nexpired: false/) }
   end
 end


### PR DESCRIPTION
The chef-server-ingredient cookbook is now fully deprecated, and we
should use the chef-ingredient cookbook instead. We're pinning to 0.7.0
to ensure we get the latest version fix, with product_name used instead
of package_name (see the chef-ingredient cookbook readme).

Please review @chef-cookbooks/engineering-services 