### PR TITLE
Use ingredient_config resource to update the configuration.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,5 @@ group :development do
   gem 'guard-foodcritic'
   gem 'guard-rspec'
   gem 'guard-rubocop'
+  gem 'mixlib-versioning'
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,14 +1,13 @@
 
 module ChefServerCoobook
   module Helpers
-    def api_fqdn_node_attr
+    def api_fqdn_available?
       return false if node['chef-server'].nil?
       return false if node['chef-server']['api_fqdn'].nil?
-      return false if node['chef-server']['api_fqdn'].empty?
-      true
+      !node['chef-server']['api_fqdn'].empty?
     end
 
-    def api_fqdn_resolves
+    def api_fqdn_resolves?
       require 'resolv'
       Resolv.getaddress(node['chef-server']['api_fqdn'])
       return true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,16 +20,17 @@ cache_path = Chef::Config[:file_cache_path]
 ruby_block 'ensure node can resolve API FQDN' do
   extend ChefServerCoobook::Helpers
   block { repair_api_fqdn }
-  only_if { api_fqdn_node_attr }
-  not_if { api_fqdn_resolves }
+  only_if { api_fqdn_available? }
+  not_if { api_fqdn_resolves? }
 end
 
 chef_ingredient 'chef-server' do
+  extend ChefServerCoobook::Helpers
   version node['chef-server']['version']
   package_source node['chef-server']['package_source']
   config <<-EOS
 topology "#{node['chef-server']['topology']}"
-api_fqdn "#{node['chef-server']['api_fqdn']}"
+#{"api_fqdn \"#{node['chef-server']['api_fqdn']}\"" if api_fqdn_available?}
 #{node['chef-server']['configuration']}
 EOS
   action :install

--- a/spec/centos_65_spec.rb
+++ b/spec/centos_65_spec.rb
@@ -4,7 +4,8 @@ describe 'chef-server::default' do
   cached(:centos_65) do
     ChefSpec::SoloRunner.new(
       platform: 'centos',
-      version: '6.5'
+      version: '6.5',
+      step_into: %w(chef_ingredient)
     ) do |node|
       node.set['chef-server']['version'] = nil
     end.converge('chef-server::default')
@@ -12,7 +13,7 @@ describe 'chef-server::default' do
 
   context 'compiling the test recipe' do
     it 'installs chef_server_ingredient[chef-server-core]' do
-      expect(centos_65).to install_chef_server_ingredient('chef-server-core')
+      expect(centos_65).to install_chef_ingredient('chef-server')
     end
   end
 end


### PR DESCRIPTION
@jtimberman single kitchen run is looking good. Running the full suite now. 

Are we cool with changing the configuration from `Hash` to `String`? I am not sure how many people are using this but this will be a breaking change. We can still preserve the old functionality by moving the logic in the template to a helper method, deprecating the `configuration` parameter and introducing a new parameter called something other than `configuration` if we want to.