### PR TITLE
Missing kitchen-vagrant dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ end
 group :development do
   gem 'ruby_gntp'
   gem 'growl'
+  gem 'kitchen-vagrant'
   gem 'rb-fsevent'
   gem 'guard', '~> 2.4'
   gem 'guard-kitchen'


### PR DESCRIPTION
Can not use bundle exec kitchen list without this dependency.
Add kitchen-vagrant into Gemfile