### PR TITLE
Add Ubuntu 14 as supported platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This cookbook is tested on the following platforms using the
 - Ubuntu 10.04, 10.10 64-bit
 - Ubuntu 11.04, 11.10 64-bit
 - Ubuntu 12.04, 12.10 64-bit
+- Ubuntu 14.04, 14.10 64-bit
 
 Unlisted platforms in the same family, of similar or equivalent
 versions may work with or without modification to this cookbook. For a


### PR DESCRIPTION
Found Ubuntu 14 is tested https://github.com/chef-cookbooks/chef-server/blob/master/.kitchen.yml#L12 but not included in README and this would really conclude https://github.com/chef-cookbooks/chef-server/issues/48