### PR TITLE
Improved addons documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Attribute        | Description |Type | Default
 api_fqdn         | Fully qualified domain name that you want to use for accessing the Web UI and API. If set to `nil` or empty string (`""`), the IP address will be used as hostname. | String | node['fqdn']
 configuration    | Configuration to pass down to the underlying server config file (i.e. `/etc/chef-server/chef-server.rb`). | String | ""
 version          | Chef Server version to install. If `nil`, the latest version is installed | String | nil
-addons           | Array of addon packages | Array | Array.new
+addons           | Array of addon packages (you need to add the addons recipe to the run list for the addons to be installed) | Array | Array.new
 
 Previous versions of this cookbook had several other attributes used
 to control the version of the Chef Server package to install. This is


### PR DESCRIPTION
I've add the requirement to add the addons recipe to the run list when the addons attribute is set.
I was expecting it to happen automatically but that was not the case.

Hoping to save someone debugging time by adding this line.

Would you be willing to accept a PR that includes the addons recipe when the addons attribute is not an empty array?