### PR TITLE
Added the ability to specify a local package for chef-ingredient to use for addons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ can be installed.
 This recipe iterates through the `node['chef-server']['addons']`
 attribute and installs and reconfigures all the packages listed.
 
+You can specify Addons as a string in the array or a hash like so:
+
+```
+node['chef-server']['addons'] = [
+  'manage',
+  {'reporting' => '~/reporting.deb' }
+]
+```
+
 
 Install Methods
 ===============

--- a/recipes/addons.rb
+++ b/recipes/addons.rb
@@ -14,7 +14,14 @@
 # limitations under the License.
 #
 node['chef-server']['addons'].each do |addon|
-  chef_ingredient addon do
-    notifies :reconfigure, "chef_ingredient[#{addon}]"
+  if addon.is_a?(Hash)
+    chef_ingredient addon.keys[0] do
+      package_source addon.values[0]
+      notifies :reconfigure, "chef_ingredient[#{addon.keys[0]}]"
+    end
+  else
+    chef_ingredient addon do
+      notifies :reconfigure, "chef_ingredient[#{addon}]"
+    end
   end
 end


### PR DESCRIPTION
The syntax for adding addons with packagecloud will stay the same.
To add a local package you just need to specify the attribute:
node['chef-server']['addons'] = [ { 'manage' => '~/mypackage.deb' } ]

The package needs to be located on the VM so to test you will probably
want to add a synced folder to kitchen.yml.