### PR TITLE
Fixes #105, move the fqdn_resolves method

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -8,11 +8,8 @@ module ChefServerCookbook
     end
 
     def api_fqdn_resolves?
-      require 'resolv'
-      Resolv.getaddress(node['chef-server']['api_fqdn'])
-      return true
-    rescue
-      false
+      extend ChefIngredientCookbook::Helpers
+      fqdn_resolves?(node['chef-server']['api_fqdn'])
     end
 
     def repair_api_fqdn

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -8,8 +8,9 @@ module ChefServerCookbook
     end
 
     def api_fqdn_resolves?
-      extend ChefIngredientCookbook::Helpers
-      fqdn_resolves?(node['chef-server']['api_fqdn'])
+      ChefIngredientCookbook::Helpers.fqdn_resolves?(
+        node['chef-server']['api_fqdn']
+      )
     end
 
     def repair_api_fqdn

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,7 +16,6 @@
 
 cache_path = Chef::Config[:file_cache_path]
 
-# see helpers.rb
 ruby_block 'ensure node can resolve API FQDN' do
   extend ChefServerCookbook::Helpers
   block { repair_api_fqdn }


### PR DESCRIPTION
The api_fqdn_resolves? method should use the new method that is in the chef-ingredient cookbook. It is implemented in that cookbook here:

- https://github.com/chef-cookbooks/chef-ingredient/commit/14a54e9dfa10333b666aa9c90947c9e6f4a86e73

Reference:

- https://github.com/chef-cookbooks/chef-ingredient/pull/36
- https://github.com/chef-cookbooks/chef-ingredient/issue/35