### PR TITLE
Change package-source to package_source to match the recipe and spec.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 #
 #
 default['chef-server']['version'] = nil
-default['chef-server']['package-source'] = nil
+default['chef-server']['package_source'] = nil
 
 # The Chef Server must have an API FQDN set.
 # Ref. http://docs.chef.io/install_server_pre.html#hostnames


### PR DESCRIPTION
Currently the ['chef-server']['package_source'] attribute does not match it's use.  Per the default recipe it should be package_source:

https://github.com/chef-cookbooks/chef-server/blob/master/recipes/default.rb#L29

As the default_spec file also uses package_source I believe the typo to be in the attributes file:

https://github.com/chef-cookbooks/chef-server/blob/master/spec/default_spec.rb#L15

This trivial patch implements an obvious fix on attributes/default.rb so that the package_source attribute is named correctly.
