### PR TITLE
Require the latest chef-ingredient so we use packages.chef.io

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -58,3 +58,4 @@ suites:
       api_fqdn: ''
       addons:
         - manage
+        - sync

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -49,3 +49,4 @@ suites:
       api_fqdn: ''
       addons:
         - manage
+        - sync

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   matrix:
   - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-centos-7
+  - INSTANCE=add-ons-no-fqdn-ubuntu-1404
+  - INSTANCE=add-ons-no-fqdn-centos-7
 
 # Don't `bundle install`
 install: echo "skip bundle install"

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Previous versions of this cookbook used `configuration` as a Hash. This is now d
 
 See <https://docs.chef.io/config_rb_server.html> for configuration options for Chef Server and below table for addons:
 
-Addon       | Product Name                  | Config Documentation
------------ | ----------------------------- | ----------------------------------------------------
-manage      | Management Console            | https://docs.chef.io/config_rb_manage.html
-chef-ha     | Chef Server High Availability | https://docs.chef.io/server_high_availability.html
-chef-sync   | Chef Server Replication       | https://docs.chef.io/config_rb_chef_sync.html
-reporting   | Chef Server Reporting         | No separate config.
-push-server | Chef Push Server              | https://docs.chef.io/config_rb_push_jobs_server.html
-supermarket | Supermarket                   | https://docs.chef.io/config_rb_supermarket.html
+Addon            | Product Name                  | Config Documentation
+---------------- | ----------------------------- | ----------------------------------------------------
+manage           | Management Console            | https://docs.chef.io/config_rb_manage.html
+ha               | Chef Server High Availability | https://docs.chef.io/server_high_availability.html
+sync             | Chef Server Replication       | https://docs.chef.io/config_rb_chef_sync.html
+reporting        | Chef Server Reporting         | No separate config.
+push-jobs-server | Chef Push Server              | https://docs.chef.io/config_rb_push_jobs_server.html
+supermarket      | Supermarket                   | https://docs.chef.io/config_rb_supermarket.html
 
 ## Recipes
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Unlisted platforms in the same family, of similar or equivalent versions may wor
 
 ### Cookbooks
 
-- chef-ingredient >= 0.11
+- chef-ingredient >= 0.18
 
 ## Attributes
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs and configures Chef Server 12'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-depends 'chef-ingredient', '>= 0.11.0'
+depends 'chef-ingredient', '>= 0.18.0'
 
 supports 'redhat'
 supports 'centos'

--- a/test/integration/add-ons-no-fqdn/serverspec/default_spec.rb
+++ b/test/integration/add-ons-no-fqdn/serverspec/default_spec.rb
@@ -1,11 +1,23 @@
 require_relative './spec_helper'
 
 describe 'chef-server' do
-  describe package('opscode-manage') do
+  describe package('chef-server-core') do
     it { should be_installed }
   end
 
-  describe command('opscode-manage-ctl test') do
+  describe package('chef-manage') do
+    it { should be_installed }
+  end
+
+  describe package('chef-sync') do
+    it { should be_installed }
+  end
+
+  describe command('chef-manage-ctl status') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe command('sudo chef-sync-ctl sync-status') do
     its(:exit_status) { should eq 0 }
   end
 end


### PR DESCRIPTION
Our existing package provider is going to be deprecated at the end of this month.  We need to upgrade this recipe to use the new package source and to use the new addon names in chef-ingredient 0.18.