### PR TITLE
Fix for license acceptance prompt

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,7 @@ default['chef-server']['api_fqdn'] = node['fqdn']
 
 default['chef-server']['topology'] = 'standalone'
 default['chef-server']['addons'] = []
+default['chef-server']['accept_license'] = nil
 
 #
 # Chef Server Tunables

--- a/recipes/addons.rb
+++ b/recipes/addons.rb
@@ -18,6 +18,7 @@
 #
 node['chef-server']['addons'].each do |addon|
   chef_ingredient addon do
+    accept_license node['chef-server']['accept_license'] unless node['chef-server']['accept_license'].nil?
     notifies :reconfigure, "chef_ingredient[#{addon}]"
   end
 end


### PR DESCRIPTION
### Description

Provides `accept_license` to addons in the chef_ingredient resource

### Issues Resolved
- chef-cookbooks/chef-server/120 - Apply attribute and parameter to chef_ingredient call on [addons.rb](recipes/addons.rb)
- Might be an obvious fix, I'll let a merge person decide this.