### PR TITLE
adding missing chef_compat to dependency list in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ sudo mkdir -p /var/chef/cache /var/chef/cookbooks
 # pull down this chef-server cookbook
 wget -qO- https://supermarket.chef.io/cookbooks/chef-server/download | sudo tar xvzC /var/chef/cookbooks
 # pull down dependency cookbooks
-for dep in chef-ingredient yum-chef yum apt-chef apt packagecloud compat_resource
+for dep in chef-ingredient chef_compat yum-chef yum apt-chef apt packagecloud compat_resource
 do
   wget -qO- https://supermarket.chef.io/cookbooks/${dep}/download | sudo tar xvzC /var/chef/cookbooks
 done
@@ -97,7 +97,7 @@ done
 sudo chef-solo -o 'recipe[chef-server::default]'
 ```
 
-Be sure to download and untar the `chef-ingredient`, `yum-chef`, `yum`, `apt-chef`, `apt`, and `packagecloud` cookbooks. They're dependencies of this cookbook.
+Be sure to download and untar the `chef-ingredient`, `yum-chef`, `yum`, `apt-chef`, `apt`, `chef_compat` and `packagecloud` cookbooks. They're dependencies of this cookbook.
 
 If you need more control over the final configuration of your Chef Server instance you can create a JSON attributes file and set underlying configuration via the `node['chef-server']['configuration']` attribute. See the [attributes file](chef-server/attributes/default.rb).
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ sudo mkdir -p /var/chef/cache /var/chef/cookbooks
 # pull down this chef-server cookbook
 wget -qO- https://supermarket.chef.io/cookbooks/chef-server/download | sudo tar xvzC /var/chef/cookbooks
 # pull down dependency cookbooks
-for dep in chef-ingredient chef_compat yum-chef yum apt-chef apt packagecloud compat_resource
+for dep in chef-ingredient yum-chef yum apt-chef apt packagecloud compat_resource
 do
   wget -qO- https://supermarket.chef.io/cookbooks/${dep}/download | sudo tar xvzC /var/chef/cookbooks
 done
@@ -97,7 +97,7 @@ done
 sudo chef-solo -o 'recipe[chef-server::default]'
 ```
 
-Be sure to download and untar the `chef-ingredient`, `yum-chef`, `yum`, `apt-chef`, `apt`, `chef_compat` and `packagecloud` cookbooks. They're dependencies of this cookbook.
+Be sure to download and untar the `chef-ingredient`, `yum-chef`, `yum`, `apt-chef`, `apt`, `compat_resource` and `packagecloud` cookbooks. They're dependencies of this cookbook.
 
 If you need more control over the final configuration of your Chef Server instance you can create a JSON attributes file and set underlying configuration via the `node['chef-server']['configuration']` attribute. See the [attributes file](chef-server/attributes/default.rb).
 


### PR DESCRIPTION
### Description

Adding the missing compat_resource dependency to setup and documentation section of the README.md 

### Issues Resolved

No existing issues exist for this.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


