### PR TITLE
Pin chef-ingredient to ~> 1.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs and configures Chef Server 12'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-depends 'chef-ingredient', '>= 0.18.0'
+depends 'chef-ingredient', '~> 1.0'
 
 supports 'redhat'
 supports 'centos'


### PR DESCRIPTION
### Description

`chef-ingredient` v2.0.0 introduces breaking changes, so this pins us to `chef-ingredient` ~> 1.0.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
