### PR TITLE
adding version locking for addons and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Attribute      | Description                                                    
 api_fqdn       | Fully qualified domain name that you want to use for accessing the Web UI and API. If set to `nil` or empty string (`""`), the IP address will be used as hostname. | String  | node['fqdn']
 configuration  | Configuration to pass down to the underlying server config file (i.e. `/etc/chef-server/chef-server.rb`).                                                           | String  | ""
 version        | Chef Server version to install. If `nil`, the latest version is installed                                                                                           | String  | nil
-addons         | Array of addon packages (you need to add the addons recipe to the run list for the addons to be installed)                                                          | Array   | Array.new
+addons         | Array of addon packages, or Hash if you want to lock addon version Example: {package1:'1.2.3'} (you need to add the addons recipe to the run list for the addons to be installed) | Array  | []
 accept_license | A boolean value that specifies if license should be accepted if it is asked for during reconfigure.                                                                 | Boolean | false
 
 Previous versions of this cookbook had several other attributes used to control the version of the Chef Server package to install. This is deprecated.
@@ -57,9 +57,12 @@ This recipe:
 
 ### addons
 
-Chef addons are premium features that can be installed on the Chef Server with the [appropriate license](https://www.chef.io/chef/#plans-and-pricing). If there are < 25 nodes managed, or a paid subscription license, addons can be installed.
+Chef addons are premium features that can be installed on the Chef Server with the [appropriate license](https://www.chef.io/chef/#plans-and-pricing). If there are under 25 nodes managed, or a paid subscription license, addons can be installed.
 
-This recipe iterates through the `node['chef-server']['addons']` attribute and installs and reconfigures all the packages listed.
+This recipe iterates through the `node['chef-server']['addons']` attribute and installs and reconfigures all the packages listed.  
+_Note_: When multiple add-ons are installed, and one of them has version locked, either lock versions of all packages (best practice) or set version to `nil`
+Example:  
+default['chef-server']['addons'] = {'chef-manage' => '2.5.0', reporting: nil}
 
 ## Install Methods
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,8 @@ default['chef-server']['api_fqdn'] = node['fqdn']
 
 default['chef-server']['topology'] = 'standalone'
 default['chef-server']['addons'] = []
+# Example of installing specific version of manage:
+# default['chef-server']['addons'] = {'chef-manage' => '2.5.0'}
 
 # Chef Licensing requirements
 # https://docs.chef.io/install_server.html

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'chef-server'
-version '5.3.0'
+version '5.3.1'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'

--- a/recipes/addons.rb
+++ b/recipes/addons.rb
@@ -16,9 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-node['chef-server']['addons'].each do |addon|
+node['chef-server']['addons'].each do |addon, ver|
   chef_ingredient addon do
     accept_license node['chef-server']['accept_license'] unless node['chef-server']['accept_license'].nil?
     notifies :reconfigure, "chef_ingredient[#{addon}]"
+    version ver if defined?(ver)
   end
 end

--- a/spec/addons_spec.rb
+++ b/spec/addons_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe 'chef-server::addons' do
   cached(:subject) do
     ChefSpec::SoloRunner.new do |node|
-      node.normal['chef-server']['addons'] = %w(manage reporting)
+      node.normal['chef-server']['addons'] = { manage: '2.5.0', reporting: nil }
     end.converge(described_recipe)
   end
 
   it 'installs addons' do
-    expect(subject).to install_chef_ingredient('manage')
-    expect(subject).to install_chef_ingredient('reporting')
+    expect(subject).to install_chef_ingredient('manage').with_version('2.5.0')
+    expect(subject).to install_chef_ingredient('reporting').with_version(:latest)
   end
 end


### PR DESCRIPTION
### Description

adds ability to specify versions of addons.
This will guarantee that chef server created by this cookbook will be exactly the same every time.

### Issues Resolved

https://github.com/chef-cookbooks/chef-server/issues/138

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
