### PR TITLE
Pin chef-ingredients version in shell snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ This recipe:
 
 Chef addons are premium features that can be installed on the Chef Server with the [appropriate license](https://www.chef.io/chef/#plans-and-pricing). If there are under 25 nodes managed, or a paid subscription license, addons can be installed.
 
-This recipe iterates through the `node['chef-server']['addons']` attribute and installs and reconfigures all the packages listed.  
+This recipe iterates through the `node['chef-server']['addons']` attribute and installs and reconfigures all the packages listed.
 _Note_: When multiple add-ons are installed, and one of them has version locked, either lock versions of all packages (best practice) or set version to `nil`
-Example:  
+Example:
 default['chef-server']['addons'] = {'chef-manage' => '2.5.0', reporting: nil}
 
 ## Install Methods
@@ -83,7 +83,7 @@ done
 # chef-server does not work with the latest chef-ingredients, so get 1.1.0
 # per the fix found in issue #137
 knife cookbook site download chef-ingredient 1.1.0
-sudo tar xvzC chef-ingredient 1.1.0.tar.gz /var/chef/cookbooks && rm -f chef-ingredient 1.1.0.tar.gz
+sudo tar xvzf chef-ingredient-1.1.0.tar.gz -C /var/chef/cookbooks && rm -f chef-ingredient-1.1.0.tar.gz
 # GO GO GO!!!
 sudo chef-solo -o 'recipe[chef-server::default]'
 ```

--- a/README.md
+++ b/README.md
@@ -76,10 +76,14 @@ sudo mkdir -p /var/chef/cache /var/chef/cookbooks
 # pull down this chef-server cookbook
 wget -qO- https://supermarket.chef.io/cookbooks/chef-server/download | sudo tar xvzC /var/chef/cookbooks
 # pull down dependency cookbooks
-for dep in chef-ingredient yum-chef yum apt-chef apt packagecloud compat_resource
+for dep in yum-chef yum apt-chef apt packagecloud compat_resource
 do
   wget -qO- https://supermarket.chef.io/cookbooks/${dep}/download | sudo tar xvzC /var/chef/cookbooks
 done
+# chef-server does not work with the latest chef-ingredients, so get 1.1.0
+# per the fix found in issue #137
+knife cookbook site download chef-ingredient 1.1.0
+sudo tar xvzC chef-ingredient 1.1.0.tar.gz /var/chef/cookbooks && rm -f chef-ingredient 1.1.0.tar.gz
 # GO GO GO!!!
 sudo chef-solo -o 'recipe[chef-server::default]'
 ```


### PR DESCRIPTION

### Description
When I tried to install chef-server with the current version of the
cookbook from github, I got the same

```
Could not satisfy version constraints for: chef-ingredient
```

error that is detailed in #137.

This updates README.md to make it easier for people to get started.

### Issues Resolved

It doesn't resolve #137, but it does document the workaround.

### Check List

This PR is a documentation-only change.

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
