### PR TITLE
Fix Test Kitchen in Travis

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -8,7 +8,7 @@ transport:
 
 provisioner:
   name: dokken
-  chef_zero_port: 9010
+  chef_options: '-z --chef-zero-port 9010'
 
 verifier:
   name: inspec
@@ -19,7 +19,7 @@ platforms:
     image: dokken/amazonlinux
     pid_one_command: /sbin/init
     intermediate_instructions:
-      - RUN yum -y crontabs
+      - RUN yum install -y crontabs
 
 - name: debian-7
   driver:
@@ -47,14 +47,14 @@ platforms:
     image: dokken/centos-6
     pid_one_command: /sbin/init
     intermediate_instructions:
-      - RUN yum -y crontabs
+      - RUN yum install -y crontabs
 
 - name: centos-7
   driver:
     image: dokken/centos-7
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN yum -y crontabs
+      - RUN yum install -y crontabs
 
 - name: ubuntu-14.04
   driver:
@@ -69,6 +69,7 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install -y tzdata cron
 
 suites:
 - name: default

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,30 +1,28 @@
 require 'resolv'
 
-control 'chef-server' do
-  describe package('chef-server-core') do
-    it { should be_installed }
-  end
+describe package('chef-server-core') do
+  it { should be_installed }
+end
 
-  describe file('/etc/opscode/chef-server.rb') do
-    its(:content) { should match(/^topology "standalone"$/) }
-    its(:content) { should match(/^api_fqdn ".+"$/) }
-  end
+describe file('/etc/opscode/chef-server.rb') do
+  its(:content) { should match(/^topology "standalone"$/) }
+  its(:content) { should match(/^api_fqdn ".+"$/) }
+end
 
-  describe file('/etc/hosts') do
-    its(:content) { should match(/127.0.0.1 chef-server-tk.example.com/) }
-  end
+describe file('/etc/hosts') do
+  its(:content) { should match(/127.0.0.1 chef-server-tk.example.com/) }
+end
 
-  describe command('chef-server-ctl test') do
-    its(:exit_status) { should eq 0 }
-  end
+describe command('chef-server-ctl test') do
+  its(:exit_status) { should eq 0 }
+end
 
-  describe command('chef-server-ctl org-list') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/sample/) }
-  end
+describe command('chef-server-ctl org-list') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/sample/) }
+end
 
-  describe command('chef-server-ctl list-user-keys exemplar') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/name: default\nexpired: false/) }
-  end
+describe command('chef-server-ctl list-user-keys exemplar') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/name: default\nexpired: false/) }
 end


### PR DESCRIPTION
Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>

### Description

This fixes the tests in Travis for CentOS 7 and Ubuntu 16.04... it also fixes CentOS 6 and Amazon Linux work container creation, but I didn't explicitly test these.

- Dokken doesn't use `chef_zero_port` (should it? my coworkers seem to think so)
- Using `yum` without a command is fatal
- Ubuntu 16.04 images needs `tzdata` and `cron` for cookbook converge
- Unwrap InSpec tests in `control` so we get cool check boxes.
```
  System Package
     ✔  chef-server-core should be installed
```

### Issues Resolved

None filed.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
