### PR TITLE
This bumps the version of chef-ingredient

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs and configures Chef Server 12'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-depends 'chef-ingredient', '~> 1.1'
+depends 'chef-ingredient', '~> 2.1'
 
 supports 'redhat'
 supports 'centos'


### PR DESCRIPTION
- The newest version of chef-ingredient is 2.x, this allows for the
  newer cookbook to work with this cookbook.

Signed-off-by: JJ Asghar <jj@chef.io>
