### PR TITLE
Update resource name to match latest version of chef-ingredient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the chef-server cookbook.
 
+## 5.5.3 (2019-01-11)
+
+- Bug change to update `chef_server` resource inside chef-ingredient cookbook [@oscar123mendoza](https://github.com/oscar123mendoza)
+
 ## 5.5.2 (2018-07-24)
 
 - Test add-ons installation in Travis

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'chef-server'
-version '5.5.2'
+version '5.5.3'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,7 @@ ruby_block 'ensure node can resolve API FQDN' do
   not_if { api_fqdn_resolves? }
 end
 
-chef_ingredient 'chef-server' do
+chef_ingredient 'chef_server' do
   extend ChefServerCookbook::Helpers
   version node['chef-server']['version'] unless node['chef-server']['version'].nil?
   package_source node['chef-server']['package_source']
@@ -43,5 +43,5 @@ file "#{cache_path}/chef-server-core.firstrun" do
 end
 
 ingredient_config 'chef-server' do
-  notifies :reconfigure, 'chef_ingredient[chef-server]', :immediately
+  notifies :reconfigure, 'chef_ingredient[chef_server]', :immediately
 end


### PR DESCRIPTION
### Description

Im not sure why the maintainers of chef-ingredient didn't make this a breaking change but oh well. Linked is the matching resource name.

https://github.com/chef-cookbooks/chef-ingredient/blob/master/resources/server.rb#L21

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
