### PR TITLE
Honors accept_license for the Chef Infra Server install

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -22,15 +22,24 @@ suites:
 - name: default
   run_list:
   - recipe[test::default]
+  attributes:
+    chef-server:
+      accept_license: true
 - name: no-fqdn
   run_list:
   - recipe[test::no-fqdn]
   driver:
     network:
       - ['private_network', {ip: '192.168.243.2'}]
+  attributes:
+    chef-server:
+      accept_license: true
 - name: add-ons-no-fqdn
   run_list:
   - recipe[test::add-ons-no-fqdn]
   driver:
     network:
       - ['private_network', {ip: '192.168.243.3'}]
+  attributes:
+    chef-server:
+      accept_license: true

--- a/recipes/addons.rb
+++ b/recipes/addons.rb
@@ -18,7 +18,7 @@
 #
 node['chef-server']['addons'].each do |addon, ver|
   chef_ingredient addon do
-    accept_license node['chef-server']['accept_license'] unless node['chef-server']['accept_license'].nil?
+    accept_license node['chef-server']['accept_license']
     notifies :reconfigure, "chef_ingredient[#{addon}]"
     version ver unless ver.nil?
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ chef_ingredient 'chef-server' do
   extend ChefServerCookbook::Helpers
   version node['chef-server']['version'] unless node['chef-server']['version'].nil?
   package_source node['chef-server']['package_source']
+  accept_license node['chef-server']['accept_license']
   config <<-EOS
 topology "#{node['chef-server']['topology']}"
 #{"api_fqdn \"#{node['chef-server']['api_fqdn']}\"" if api_fqdn_available?}


### PR DESCRIPTION
### Description

With the new Chef Infra Server you have to accept the license to install it. This was not possible before

**INFO: Does not work without PR https://github.com/chef-cookbooks/chef-ingredient/pull/241**

### Issues Resolved

 - minor fix of redundant code
 - accept_license is passed to the chef-ingredient resource

### Check List

- `delivery local all` succeeds
- `kitchen test` succeeds