### PR TITLE
honor accept_license attribute

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -22,15 +22,24 @@ suites:
 - name: default
   run_list:
   - recipe[test::default]
+  attributes:
+    chef-server:
+      accept_license: true
 - name: no-fqdn
   run_list:
   - recipe[test::no-fqdn]
   driver:
     network:
       - ['private_network', {ip: '192.168.243.2'}]
+  attributes:
+    chef-server:
+      accept_license: true
 - name: add-ons-no-fqdn
   run_list:
   - recipe[test::add-ons-no-fqdn]
   driver:
     network:
       - ['private_network', {ip: '192.168.243.3'}]
+  attributes:
+    chef-server:
+      accept_license: true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ chef_ingredient 'chef-server' do
   extend ChefServerCookbook::Helpers
   version node['chef-server']['version'] unless node['chef-server']['version'].nil?
   package_source node['chef-server']['package_source']
+  accept_license node['chef-server']['accept_license']
   config <<-EOS
 topology "#{node['chef-server']['topology']}"
 #{"api_fqdn \"#{node['chef-server']['api_fqdn']}\"" if api_fqdn_available?}


### PR DESCRIPTION
Signed-off-by: Ric Caliolio <riccaliolio@gmail.com>

### Description
The new Chef Infra Server requires acceptance of license to install it. This enables license acceptance by using an attribute (`node['chef-server']['accept_license']`).

### Issues Resolved

- accept_license attribute is passed to the chef-ingredient resource

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>