### PR TITLE
Allow `options` to be passed to `chef_ingredient`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Attribute      | Description                                                    
 api_fqdn       | Fully qualified domain name that you want to use for accessing the Web UI and API. If set to `nil` or empty string (`""`), the IP address will be used as hostname. | String  | node['fqdn']
 configuration  | Configuration to pass down to the underlying server config file (i.e. `/etc/chef-server/chef-server.rb`).                                                           | String  | ""
 version        | Chef Server version to install. If `nil`, the latest version is installed                                                                                           | String  | nil
+options | options passed onto to chef_ingredient | String | nil
 addons         | Array of addon packages, or Hash if you want to lock addon version Example: {package1:'1.2.3'} (you need to add the addons recipe to the run list for the addons to be installed) | Array  | []
 accept_license | A boolean value that specifies if license should be accepted if it is asked for during reconfigure.                                                                 | Boolean | false
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@
 #
 default['chef-server']['version'] = nil
 default['chef-server']['package_source'] = nil
+default['chef-server']['options'] = nil
 
 # The Chef Server must have an API FQDN set.
 # Ref. http://docs.chef.io/install_server_pre.html#hostnames

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ chef_ingredient 'chef-server' do
   extend ChefServerCookbook::Helpers
   version node['chef-server']['version'] unless node['chef-server']['version'].nil?
   package_source node['chef-server']['package_source']
+  options node['chef-server']['options'] unless node['chef-server']['options'].nil?
   accept_license node['chef-server']['accept_license']
   config <<-EOS
 topology "#{node['chef-server']['topology']}"


### PR DESCRIPTION
Signed-off-by: Joe Nuspl <nuspl@nvwls.com>

### Description
Allow `options` to be passed to `chef_ingredient`

### Issues Resolved
None

### Check List

- [/ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [/] New functionality includes testing.
- [/] New functionality has been documented in the README if applicable
- [/] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>